### PR TITLE
Revamp homepage hero presentation

### DIFF
--- a/css/index-v3.css
+++ b/css/index-v3.css
@@ -1,5 +1,8 @@
 body {
   font-family: 'Noto Sans', sans-serif;
+  background-color: #f8fafc;
+  color: #0f172a;
+  line-height: 1.65;
 }
 
 
@@ -506,5 +509,439 @@ body {
   .canvas-row {
     flex-direction: column;    /* stack canvases vertically on small screens */
     gap: 1.5rem;
+  }
+}
+/* Landing hero styling */
+.hero.is-landing {
+  background: radial-gradient(120% 120% at 20% 0%, #eef2ff 0%, #ffffff 55%, #f5f3ff 100%);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero.is-landing::before,
+.hero.is-landing::after {
+  content: "";
+  position: absolute;
+  border-radius: 999px;
+  opacity: 0.7;
+  z-index: 0;
+}
+
+.hero.is-landing::before {
+  width: 460px;
+  height: 460px;
+  top: -160px;
+  right: -120px;
+  background: radial-gradient(circle at center, rgba(79, 70, 229, 0.25), rgba(79, 70, 229, 0));
+}
+
+.hero.is-landing::after {
+  width: 360px;
+  height: 360px;
+  bottom: -160px;
+  left: -120px;
+  background: radial-gradient(circle at center, rgba(14, 165, 233, 0.18), rgba(14, 165, 233, 0));
+}
+
+.hero.is-landing .hero-body {
+  position: relative;
+  z-index: 1;
+  padding: 4.5rem 1.5rem 3.5rem;
+}
+
+.landing-card {
+  position: relative;
+  z-index: 1;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 32px;
+  padding: 3rem 3rem 2.5rem;
+  border: 1px solid rgba(99, 102, 241, 0.15);
+  box-shadow: 0 48px 96px -60px rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(10px);
+}
+
+.landing-columns {
+  margin-bottom: 2.5rem;
+}
+
+.conference-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.55rem 1.2rem;
+  border-radius: 999px;
+  background: linear-gradient(120deg, #312e81, #6366f1);
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  box-shadow: 0 24px 40px -28px rgba(79, 70, 229, 0.85);
+}
+
+.conference-name {
+  font-size: 0.95rem;
+  letter-spacing: 0.1em;
+}
+
+.spotlight-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.hero-subtitle {
+  margin-top: 1rem;
+  font-size: 1.2rem;
+  max-width: 560px;
+  color: #334155;
+  font-weight: 500;
+}
+
+.hero-links {
+  margin-top: 2.2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+}
+
+.hero-links .link-block {
+  margin: 0;
+}
+
+.hero-links .link-block a {
+  margin: 0;
+  min-width: 150px;
+  border: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.6rem;
+  background: linear-gradient(135deg, #4338ca, #6366f1);
+  color: #fff;
+  box-shadow: 0 28px 50px -26px rgba(79, 70, 229, 0.85);
+}
+
+.hero-links .link-block a:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 30px 56px -26px rgba(79, 70, 229, 0.95);
+}
+
+.hero-links .link-block a:focus-visible {
+  outline: 2px solid rgba(99, 102, 241, 0.65);
+  outline-offset: 4px;
+}
+
+.hero-links .link-block a .icon {
+  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hero-links .link-block a img {
+  filter: brightness(0) invert(1);
+}
+
+.hero-highlight {
+  background: linear-gradient(160deg, rgba(59, 130, 246, 0.12), rgba(99, 102, 241, 0.08));
+  border-radius: 24px;
+  padding: 2rem 1.8rem;
+  box-shadow: 0 36px 70px -52px rgba(30, 64, 175, 0.55);
+  border: 1px solid rgba(99, 102, 241, 0.24);
+  color: #1f2937;
+}
+
+.hero-highlight h3 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #312e81;
+  margin-bottom: 1.2rem;
+}
+
+.hero-highlight-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.hero-highlight-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 1rem;
+  line-height: 1.55;
+}
+
+.hero-highlight-list li::before {
+  content: "";
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: radial-gradient(circle at center, #6366f1 0%, rgba(99, 102, 241, 0.3) 100%);
+  box-shadow: 0 0 0 6px rgba(99, 102, 241, 0.15);
+  flex-shrink: 0;
+}
+
+.authors-block {
+  text-align: center;
+  color: #1e293b;
+}
+
+.authors-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.65rem 1.5rem;
+  font-size: 1.08rem;
+  font-weight: 500;
+}
+
+.authors-list .author a {
+  color: #3730a3;
+}
+
+.authors-list .author a:hover {
+  text-decoration: underline;
+}
+
+.authors-block sup {
+  font-size: 0.75em;
+  margin-left: 2px;
+  color: #6366f1;
+}
+
+.authors-affiliations {
+  margin-top: 0.85rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem 1.5rem;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.authors-equal {
+  margin-top: 0.65rem;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.tldr-card {
+  margin: 2.5rem auto 0;
+  max-width: 720px;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.95), rgba(236, 233, 254, 0.95));
+  border-radius: 20px;
+  padding: 1.5rem 2rem;
+  border: 1px solid rgba(79, 70, 229, 0.18);
+  box-shadow: 0 38px 70px -48px rgba(79, 70, 229, 0.6);
+  font-size: 1.05rem;
+  font-style: italic;
+  color: #1e293b;
+}
+
+.tldr-card strong {
+  font-style: normal;
+  color: #4338ca;
+  margin-right: 0.5rem;
+}
+
+.soft-section {
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.95) 0%, rgba(255, 255, 255, 0.98) 100%);
+  padding-top: 3.5rem;
+  padding-bottom: 3.5rem;
+}
+
+.content-card {
+  background: #ffffff;
+  border-radius: 28px;
+  padding: 2.5rem 2.75rem;
+  box-shadow: 0 48px 96px -68px rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.narrow-content {
+  max-width: 90%;
+  margin: 0 auto;
+}
+
+.framework-lead {
+  padding-bottom: 1rem;
+  text-align: center;
+  color: #334155;
+}
+
+.section-title {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding-left: 1.4rem;
+  color: #1e3a8a;
+}
+
+.section-title::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 6px;
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(180deg, #6366f1, #a855f7);
+}
+
+.gallery-hero {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(226, 232, 255, 0.65) 100%);
+}
+
+.gallery-hero .hero-body {
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+}
+
+.gallery-hero .viewers-container {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 24px;
+  padding: 2rem 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 42px 80px -60px rgba(59, 130, 246, 0.35);
+  min-height: 320px;
+}
+
+.gallery-hero .controls-bar {
+  margin-top: 1.5rem;
+  background: rgba(255, 255, 255, 0.94);
+  border-radius: 18px;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 35px 70px -55px rgba(30, 64, 175, 0.4);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.gallery-hero .controls-bar button {
+  background: #eef2ff;
+  border-radius: 999px;
+  border: none;
+  padding: 0.55rem 1.4rem;
+  font-weight: 600;
+  color: #3730a3;
+  transition: all 0.2s ease-in-out;
+}
+
+.gallery-hero .controls-bar button:hover,
+.gallery-hero .controls-bar button:focus {
+  background: #c7d2fe;
+  color: #1d4ed8;
+  transform: translateY(-2px);
+}
+
+.gallery-hero .rotate-controls {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.framework-hero {
+  background: linear-gradient(180deg, rgba(224, 231, 255, 0.45) 0%, rgba(255, 255, 255, 0.95) 100%);
+}
+
+.framed-image {
+  border-radius: 24px;
+  border: 1px solid rgba(99, 102, 241, 0.18);
+  box-shadow: 0 45px 90px -65px rgba(30, 58, 138, 0.7);
+  background-color: #ffffff;
+}
+
+#BibTeX pre code {
+  display: block;
+  padding: 1.5rem 1.75rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 42px 80px -65px rgba(15, 23, 42, 0.85);
+  overflow-x: auto;
+}
+
+.link-block a.button.is-dark.disabled {
+  background-color: #4a4a4a;
+  opacity: 0.75;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+@media screen and (max-width: 1215px) {
+  .landing-card {
+    padding: 2.8rem 2.5rem 2.2rem;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .hero.is-landing .hero-body {
+    padding: 3.5rem 1.5rem 3rem;
+  }
+
+  .hero-highlight {
+    margin-top: 2.5rem;
+  }
+
+  .soft-section {
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .landing-card {
+    padding: 2.4rem 1.75rem 2rem;
+  }
+
+  .hero-links {
+    justify-content: center;
+  }
+
+  .hero-subtitle {
+    font-size: 1.1rem;
+  }
+
+  .conference-badge {
+    font-size: 0.85rem;
+    padding: 0.45rem 1rem;
+  }
+
+  .tldr-card {
+    padding: 1.35rem 1.5rem;
+    font-size: 1rem;
+  }
+
+  .content-card {
+    padding: 2rem 1.75rem;
+  }
+
+  .gallery-hero .viewers-container {
+    padding: 1.5rem 1.25rem;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .conference-badge {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
+  }
+
+  .spotlight-tag {
+    width: auto;
   }
 }

--- a/index.html
+++ b/index.html
@@ -98,6 +98,7 @@
           <div class="columns is-centered">
             <div class="column has-text-centered">
               <!-- <h2 class="title is-2 publication-title"> <strong><span style="color: #006400">R</span><span style="color: #006666">e</span><span style="color: #006D6D">S</span><span style="color: #007373">t</span><span style="color: #007979">y</span><span style="color: #008080">l</span><span style="color: #008686">e</span><span style="color: #008B8B">3</span><span style="color: #009090">D</span></strong></h2> -->
+
               <h1 class="title is-2 publication-title">
                Rectified Point Flow: <br> Generic Point Cloud Pose Estimation
               </h1>
@@ -111,9 +112,11 @@
                 <br>
                 <span><sup>1</sup>Stanford University</span> 
                 <span style="margin-left: 12px;"><sup>2</sup>NVIDIA Research</span> 
-                <br>
-                <span style="font-size: .85em;"><sup>*</sup>Equal contribution</span>
+                <span style="margin-left: 20px;">(<sup>*</sup>Equal contribution)</span>
             </div>
+            <p class="has-text-centered" style="font-size: 1.1rem; font-weight: 600; margin-top: 20px; margin-bottom: 10px;">
+              <strong style="color: #b30a0a;">NeurIPS 2025 (Spotlight)</strong>
+             </p>
               <!-- Buttons -->
               <div class="column has-text-centered">
                 <div class="publication-links">

--- a/index.html
+++ b/index.html
@@ -92,31 +92,25 @@
   </head>
 
   <body>
-    <section class="hero">
+    <section class="hero is-landing">
       <div class="hero-body">
         <div class="container is-max-desktop">
-          <div class="columns is-centered">
-            <div class="column has-text-centered">
-              <!-- <h2 class="title is-2 publication-title"> <strong><span style="color: #006400">R</span><span style="color: #006666">e</span><span style="color: #006D6D">S</span><span style="color: #007373">t</span><span style="color: #007979">y</span><span style="color: #008080">l</span><span style="color: #008686">e</span><span style="color: #008B8B">3</span><span style="color: #009090">D</span></strong></h2> -->
-              <h1 class="title is-2 publication-title">
-               Rectified Point Flow: <br> Generic Point Cloud Pose Estimation
-              </h1>
-              <div style="text-align: center; line-height: 1.6; font-size: 1.2em;">
-                <span style="margin-left: 10px;"><a href="https://taosun.io/">Tao Sun</a><sup>1,*</sup></span> 
-                <span><a href="https://www.zhuliyuan.net/">Liyuan Zhu</a><sup>1,*</sup></span> 
-                <span style="margin-left: 10px;"><a href="https://shengyuh.github.io/">Shengyu Huang</a><sup>2</sup></span>
-                <!-- <br> -->
-                <span style="margin-left: 10px;"><a href="https://shurans.github.io/">Shuran Song</a><sup>1</sup></span> 
-                <span style="margin-left: 10px;"><a href="https://ir0.github.io/">Iro Armeni</a><sup>1</sup></span>
-                <br>
-                <span><sup>1</sup>Stanford University</span> 
-                <span style="margin-left: 12px;"><sup>2</sup>NVIDIA Research</span> 
-                <br>
-                <span style="font-size: .85em;"><sup>*</sup>Equal contribution</span>
-            </div>
-              <!-- Buttons -->
-              <div class="column has-text-centered">
-                <div class="publication-links">
+          <div class="landing-card">
+            <div class="columns is-variable is-vcentered landing-columns">
+              <div class="column is-7-desktop is-12-tablet">
+                <div class="conference-badge" aria-label="Publication venue">
+                  <span class="conference-name">NeurIPS 2025</span>
+                  <span class="spotlight-tag">Spotlight</span>
+                </div>
+                <h1 class="title is-2 publication-title">
+                  Rectified Point Flow: <br />
+                  Generic Point Cloud Pose Estimation
+                </h1>
+                <p class="subtitle hero-subtitle">
+                  A unified rectified flow that assembles unposed parts into coherent shapes and recovers precise poses from point clouds.
+                </p>
+                <!-- Buttons -->
+                <div class="publication-links hero-links">
                   <span class="link-block">
                     <a
                       href="https://arxiv.org/abs/2506.05282"
@@ -124,7 +118,7 @@
                       class="external-link button is-normal is-rounded"
                     >
                       <span class="icon">
-                        <i class="fas fa-file-pdf" style="color: orangered"></i>
+                        <i class="fas fa-file-pdf"></i>
                       </span>
                       <span>Paper</span>
                     </a>
@@ -143,14 +137,6 @@
                     </a>
                   </span>
                   <!-- Hugging Face Space -->
-                  <style>
-                    .link-block a.button.is-dark.disabled {
-                      background-color: #4a4a4a;
-                      opacity: 0.8;
-                      cursor: not-allowed;
-                      pointer-events: none;
-                    }
-                  </style>
                   <span class="link-block">
                     <a
                       href="https://huggingface.co/gradient-spaces/"
@@ -162,30 +148,57 @@
                     </a>
                   </span>
                   <span class="link-block">
-                  <a
-                    href="https://huggingface.co/gradient-spaces/"
-                    rel="noopener noreferrer"
-                    class="external-link button is-normal is-rounded"
-                  >
-                    <span class="icon">
-                      <img src="./images/dataset-icon.svg" alt="Dataset icon" width="16" height="16">
-                    </span>
-                    <span>Dataset</span>
-                  </a>
-                </span>
+                    <a
+                      href="https://huggingface.co/gradient-spaces/"
+                      rel="noopener noreferrer"
+                      class="external-link button is-normal is-rounded"
+                    >
+                      <span class="icon">
+                        <img src="./images/dataset-icon.svg" alt="Dataset icon" width="16" height="16" />
+                      </span>
+                      <span>Dataset</span>
+                    </a>
+                  </span>
+                </div>
+              </div>
+              <div class="column is-5-desktop is-12-tablet">
+                <div class="hero-highlight">
+                  <h3>Highlights</h3>
+                  <ul class="hero-highlight-list">
+                    <li>Unified formulation for pairwise registration and multi-part assembly.</li>
+                    <li>Symmetry-aware generative flow without handcrafted heuristics.</li>
+                    <li>State-of-the-art accuracy across six challenging benchmarks.</li>
+                  </ul>
                 </div>
               </div>
             </div>
+            <div class="authors-block">
+              <div class="authors-list">
+                <span class="author"><a href="https://taosun.io/">Tao Sun</a><sup>1,*</sup></span>
+                <span class="author"><a href="https://www.zhuliyuan.net/">Liyuan Zhu</a><sup>1,*</sup></span>
+                <span class="author"><a href="https://shengyuh.github.io/">Shengyu Huang</a><sup>2</sup></span>
+                <span class="author"><a href="https://shurans.github.io/">Shuran Song</a><sup>1</sup></span>
+                <span class="author"><a href="https://ir0.github.io/">Iro Armeni</a><sup>1</sup></span>
+              </div>
+              <div class="authors-affiliations">
+                <span><sup>1</sup>Stanford University</span>
+                <span><sup>2</sup>NVIDIA Research</span>
+              </div>
+              <div class="authors-equal">
+                <sup>*</sup>Equal contribution
+              </div>
+            </div>
+            <div class="tldr-card">
+              <strong>TL;DR:</strong>
+              A point cloud generative model that turns unposed parts into assembled shapes.
+            </div>
           </div>
-        <p class="has-text-centered" style="margin-top: 1rem; font-size: 1em; font-weight: 500; font-style: italic; color: #000;">
-          <b><i>TL;DR:</i></b>  A point cloud generative model that turns unposed parts into assembled shapes. 
-        </p>
         </div>
       </div>
     </section>
 
     <!-- Gallery -->
-    <section class="hero teaser is-small is-light" style="margin-top: -20px;">
+    <section class="hero teaser is-small is-light gallery-hero" style="margin-top: -20px;">
       <div class="is-max-desktop has-text-centered">
         <div class="hero-body">
           <!-- <h2 class="title is-5"></h2> -->
@@ -242,44 +255,44 @@
       </div>
     </section>
 
-    <section class="section pt-0">
+    <section class="section pt-0 soft-section">
       <div class="container is-max-desktop">
         <div class="columns is-centered has-text-centered">
           <div class="column is-five-fifths">
-            <!-- Abstract -->
-             <br>
-            <h3 class="title is-4">Abstract</h3>
-            <div class="has-text-justified" style="width: 90%; margin: 0 auto;">
-              <p>
-                We introduce <span class="methodname">Rectified Point Flow</span>, a unified parameterization that formulates pairwise point cloud registration and multi-part shape assembly as a single conditional generative problem. 
-                <!-- <br><br> -->
-                Given unposed point clouds, our method learns a continuous point-wise velocity field that transports noisy points toward their target positions, from which part poses are recovered. 
+            <div class="content-card">
+              <h3 class="title is-4 section-title">Abstract</h3>
+              <div class="has-text-justified narrow-content">
+                <p>
+                  We introduce <span class="methodname">Rectified Point Flow</span>, a unified parameterization that formulates pairwise point cloud registration and multi-part shape assembly as a single conditional generative problem.
+                  <!-- <br><br> -->
+                  Given unposed point clouds, our method learns a continuous point-wise velocity field that transports noisy points toward their target positions, from which part poses are recovered.
 In contrast to prior work that regresses part-wise poses with ad-hoc symmetry handling, our method intrinsically learns assembly symmetries without symmetry labels.
 <br><br>
-Together with a self-supervised encoder focused on overlapping points, our method achieves a new state-of-the-art performance on six benchmarks spanning pairwise registration and shape assembly. 
+Together with a self-supervised encoder focused on overlapping points, our method achieves a new state-of-the-art performance on six benchmarks spanning pairwise registration and shape assembly.
 Notably, our unified formulation enables effective joint training on diverse datasets, facilitating the learning of shared geometric priors and consequently boosting accuracy.
-              </p>
+                </p>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </section>
 
-    <section class="hero is-small">
+    <section class="hero is-small framework-hero">
       <div class="hero-body">
         <div class="container is-max-desktop">
-          <h3 class="title is-4 has-text-centered">Framework</h3>
-        <p style="width: 90%; margin: 0 auto; padding-bottom: 1rem">
+          <h3 class="title is-4 has-text-centered section-title">Framework</h3>
+        <p class="narrow-content framework-lead">
           Rectified Point Flow supports <span class="emph">shape assembly</span> and <span class="emph">pairwise registration</span> tasks in a single framework. Given a set of unposed part point clouds \(\{\bar {X}_i\}_{i\in\Omega}\), it predicts each part's point cloud at the target assembled state \(\{\hat {X}_i{(0)}\}_{i\in\Omega}\). Subsequently, we solve Procrustes problem via SVD between the condition point cloud \(\bar X_i\) and the estimated point cloud \(\hat X_i(0)\) to recover the rigid transformation \(\hat T_i\) for each non-anchored part.
         </p>
           <!-- Teaser figure -->
           <div class="columns is-centered has-text-centered">
             <div class="column is-fll">
               <div class="publication-teaser">
-                <img 
-                  src="images/overview_flow_asm.png" 
+                <img
+                  src="images/overview_flow_asm.png"
                   alt="ReStyle3D method teaser figure"
-                  class="publication-teaser-img"
+                  class="publication-teaser-img framed-image"
                   style="width: 90%;"
                 >
               </div>
@@ -289,7 +302,7 @@ Notably, our unified formulation enables effective joint training on diverse dat
       </div>
     </section>
 
-    <section class="section pt-0">
+    <section class="section pt-0 soft-section">
       <div class="container is-max-desktop">
         <div class="columns is-centered has-text-centered">
           <div class="column is-five-fifths">
@@ -336,7 +349,7 @@ Notably, our unified formulation enables effective joint training on diverse dat
               <!-- Quantitative table -->
               <section class="section">
                 <div class="container is-max-desktop has-text-centered is-centered">
-              <h2 class="title is-4 has-text-centered">Multi-part Shape Assembly</h2>
+              <h2 class="title is-4 has-text-centered section-title">Multi-part Shape Assembly</h2>
 
               <p class="has-text-justified" style="width: 90%; padding-bottom: 2rem; margin: 0 auto;">
                 We evaluate our method on the multi-part shape assembly task, where the goal is to estimate the poses of multiple parts given their unposed point clouds.
@@ -354,6 +367,7 @@ Notably, our unified formulation enables effective joint training on diverse dat
                     src="./images/result_assembly.png"
                     alt="Comparison with other methods"
                     style="width: 90%; display: block; margin: 0 auto;"
+                    class="framed-image"
                   >
                   <figcaption>
                     <!-- <strong>Image appearance transfer results.</strong> -->
@@ -380,7 +394,7 @@ Notably, our unified formulation enables effective joint training on diverse dat
 
               <section class="section">
                 <div class="container is-max-desktop" style="width: 90%; margin: 0 auto;">
-              <h2 class="title is-4 has-text-centered">Linear Interpolation in Noise Space</h2>
+              <h2 class="title is-4 has-text-centered section-title">Linear Interpolation in Noise Space</h2>
               <p class="has-text-justified" style="padding-bottom: 2rem; margin: 0 auto;">
                 We visualize the linear interpolation in the noise space by generating the assembled point cloud from \( Z(s) \), where  \( Z(s) \) interpolates linearly between two Gaussian noise vectors \( Z_0 \) and \( Z_1 \). We observe a continuous, semantically meaningful
 mapping from Gaussian noise to valid assemblies.
@@ -484,6 +498,7 @@ mapping from Gaussian noise to valid assemblies.
                       style="margin: 10px auto;"
                       src="./images/merge_object_same.png"
                       alt="Comparison with other methods"
+                      class="framed-image"
                     >
                   </div>
                 </div>
@@ -504,6 +519,7 @@ mapping from Gaussian noise to valid assemblies.
                       style="margin: 10px auto;"
                       src="./images/merge_object_diff.png"
                       alt="Comparison with other methods"
+                      class="framed-image"
                     >
                       
                     </div>
@@ -536,9 +552,9 @@ mapping from Gaussian noise to valid assemblies.
 
     </section> -->
     
-<section class="section" id="BibTeX" style="margin-top: -80px;">
+<section class="section soft-section" id="BibTeX" style="margin-top: -80px;">
       <div class="container is-max-desktop content px-2">
-        <h3 class="title">Concurrent Works</h3>
+        <h3 class="title section-title">Concurrent Works</h3>
           <p>
             We are pleased to see several concurrent works that explore flow matching for pose estimation. Check them as well!
             <br>
@@ -551,9 +567,9 @@ mapping from Gaussian noise to valid assemblies.
     </section>
 
 
-    <section class="section" id="BibTeX" style="margin-top: -30px;">
+    <section class="section soft-section" id="BibTeX" style="margin-top: -30px;">
       <div class="container is-max-desktop content px-2">
-        <h3 class="title">BibTeX</h3>
+        <h3 class="title section-title">BibTeX</h3>
         <pre><code>@inproceedings{sun2025_rpf,
       author = {Sun, Tao and Zhu, Liyuan and Huang, Shengyu and Song, Shuran and Armeni, Iro},
       title = {Rectified Point Flow: Generic Point Cloud Pose Estimation},


### PR DESCRIPTION
## Summary
- redesign the landing hero with a NeurIPS 2025 Spotlight badge, highlight callouts, reorganized author list, and a polished TL;DR card
- refresh supporting sections with accent section titles, framed imagery, and softer background treatments for improved readability
- add comprehensive styling for the new layout, gradients, and responsive behavior across the homepage

## Testing
- Not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68cdc9a621c4832b8189aaba9f556130